### PR TITLE
chore: move `compose()` code

### DIFF
--- a/packages/core/src/compose/index.test.ts
+++ b/packages/core/src/compose/index.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
-import { Handler } from "./types";
-import { compose } from "./compose";
+import { Handler } from "../types";
+import { compose } from "./index";
 import * as nodeFetch from "node-fetch";
 
 (globalThis as any).fetch = nodeFetch.default;

--- a/packages/core/src/compose/index.ts
+++ b/packages/core/src/compose/index.ts
@@ -1,4 +1,4 @@
-import type { Handler, Context } from "./types";
+import type { Handler, Context } from "../types";
 
 async function runHandler(
   request: Request,


### PR DESCRIPTION
So that we can collocate a `readme.md` next to `compose()`'s source code. See #5.