### PR TITLE
feat: add polyfills package

### DIFF
--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -32,12 +32,14 @@
   },
   "devDependencies": {
     "@cyco130/eslint-config": "^2.0.0",
-    "@hattip/core": "workspace:*",
     "@types/node": "^18.0.0",
     "eslint": "^8.18.0",
-    "node-fetch": "^3.2.6",
     "publint": "^0.1.1",
     "tsup": "^6.1.2",
     "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "@hattip/core": "workspace:*",
+    "@hattip/polyfills": "workspace:*"
   }
 }

--- a/packages/adapter-node/src/common.ts
+++ b/packages/adapter-node/src/common.ts
@@ -130,16 +130,11 @@ export function createMiddleware(
 
     if (!next || !passThroughCalled) {
       res.statusCode = response.status;
-      if ("raw" in response.headers) {
-        const rawHeaders: Record<string, string | string[]> = (
-          response.headers as any
-        ).raw();
-
-        for (const [key, value] of Object.entries(rawHeaders)) {
-          res.setHeader(key, value);
-        }
-      } else {
-        for (const [key, value] of response.headers) {
+      for (const [key, value] of response.headers) {
+        if (key === "set-cookie") {
+          const setCookie = response.headers.getSetCookie();
+          res.setHeader("set-cookie", setCookie);
+        } else {
           res.setHeader(key, value);
         }
       }

--- a/packages/adapter-node/src/index.ts
+++ b/packages/adapter-node/src/index.ts
@@ -1,3 +1,5 @@
+// TODO: Remove or update this rule!
+/* eslint-disable import/no-unresolved */
 import type { HattipHandler } from "@hattip/core";
 import {
   createServer as createHttpServer,
@@ -5,12 +7,16 @@ import {
   ServerResponse,
   ServerOptions,
 } from "http";
-import { Readable } from "stream";
 import {
   createMiddleware as createNodeMiddleware,
   DecoratedRequest,
   NodeAdapterOptions,
 } from "./common";
+import installNodeFetch from "@hattip/polyfills/node-fetch";
+import installGetSetCookie from "@hattip/polyfills/get-set-cookie";
+
+installNodeFetch();
+installGetSetCookie();
 
 export type { DecoratedRequest, NodeAdapterOptions };
 
@@ -35,42 +41,11 @@ export function createMiddleware(
   handler: HattipHandler,
   options: NodeAdapterOptions = {},
 ): NodeMiddleware {
-  const nodeFetchInstallPromise = installNodeFetch();
-
   const nodeAdapterHandler = createNodeMiddleware(handler, options);
 
   return async (req, res, next) => {
-    await nodeFetchInstallPromise;
     nodeAdapterHandler(req, res, next);
   };
-}
-
-/**
- * Installs `node-fetch` into the global scope.
- */
-export async function installNodeFetch() {
-  await import("node-fetch").then((nodeFetch) => {
-    (globalThis as any).fetch = nodeFetch.default;
-    (globalThis as any).Request = nodeFetch.Request;
-    (globalThis as any).Headers = nodeFetch.Headers;
-
-    // node-fetch doesn't allow constructing a Request from ReadableStream
-    // see: https://github.com/node-fetch/node-fetch/issues/1096
-    class Response extends nodeFetch.Response {
-      constructor(
-        input: import("node-fetch").BodyInit,
-        init?: import("node-fetch").ResponseInit,
-      ) {
-        if (input instanceof ReadableStream) {
-          input = Readable.from(input as any);
-        }
-
-        super(input as any, init);
-      }
-    }
-
-    (globalThis as any).Response = Response;
-  });
 }
 
 /**

--- a/packages/adapter-node/src/native-fetch.ts
+++ b/packages/adapter-node/src/native-fetch.ts
@@ -1,5 +1,8 @@
 // eslint-disable-next-line import/no-unresolved
 import { TransformStream } from "stream/web";
+import installGetSetCookie from "@hattip/polyfills/get-set-cookie";
+
+installGetSetCookie();
 
 if (!global.TransformStream) {
   global.TransformStream = TransformStream as any;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -42,3 +42,9 @@ export interface AdapterRequestContext<P = unknown> {
 export type HattipHandler = (
   context: AdapterRequestContext,
 ) => Response | Promise<Response>;
+
+declare global {
+  interface Headers {
+    getSetCookie(): string[];
+  }
+}

--- a/packages/polyfills/.eslintrc.cjs
+++ b/packages/polyfills/.eslintrc.cjs
@@ -1,0 +1,6 @@
+require("@cyco130/eslint-config/patch");
+
+module.exports = {
+  extends: ["@cyco130/eslint-config/node"],
+  parserOptions: { tsconfigRootDir: __dirname },
+};

--- a/packages/polyfills/get-set-cookie.d.ts
+++ b/packages/polyfills/get-set-cookie.d.ts
@@ -1,0 +1,1 @@
+export { default } from "./dist/get-set-cookie";

--- a/packages/polyfills/node-fetch.d.ts
+++ b/packages/polyfills/node-fetch.d.ts
@@ -1,0 +1,1 @@
+export { default } from "./dist/node-fetch";

--- a/packages/polyfills/package.json
+++ b/packages/polyfills/package.json
@@ -1,15 +1,21 @@
 {
-  "name": "@hattip/adapter-netlify-functions",
+  "name": "@hattip/polyfills",
   "version": "0.0.5",
-  "description": "Netlify Functions adapter for Hattip",
-  "module": "./dist/index.mjs",
+  "description": "Fetch API polyfills",
   "files": [
     "dist",
     "*.d.ts"
   ],
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs"
+    "./node-fetch": {
+      "types": "./dist/node-fetch.d.ts",
+      "import": "./dist/node-fetch.mjs",
+      "require": "./dist/node-fetch.js"
+    },
+    "./get-set-cookie": {
+      "types": "./dist/get-set-cookie.d.ts",
+      "import": "./dist/get-set-cookie.mjs",
+      "require": "./dist/get-set-cookie.js"
     }
   },
   "author": "Fatih Aygün <cyco130@gmail.com>",
@@ -19,7 +25,8 @@
     "build": "rimraf dist && tsup",
     "dev": "tsup --watch",
     "prepack": "pnpm build",
-    "test": "pnpm test:typecheck && pnpm test:lint && pnpm test:package",
+    "test": "pnpm test:typecheck && pnpm test:lint && pnpm test:unit && pnpm test:package",
+    "test:unit": "vitest run --reporter=verbose",
     "test:typecheck": "tsc -p tsconfig.json --noEmit",
     "test:lint": "eslint . --max-warnings 0 --ignore-pattern dist",
     "test:package": "publint"
@@ -30,12 +37,11 @@
     "eslint": "^8.18.0",
     "publint": "^0.1.1",
     "tsup": "^6.1.2",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "vitest": "^0.15.2"
   },
   "dependencies": {
-    "@hattip/adapter-node": "workspace:*",
     "@hattip/core": "workspace:*",
-    "@hattip/polyfills": "workspace:*",
-    "netlify-lambda-types": "^1.0.0"
+    "node-fetch-native": "^0.1.4"
   }
 }

--- a/packages/polyfills/readme.md
+++ b/packages/polyfills/readme.md
@@ -1,0 +1,6 @@
+# `@hattip/polyfills`
+
+Fetch API polyfills
+
+- `node-fetch`: [`node-fetch`](https://github.com/node-fetch/node-fetch) as packaged by [node-fetch-native](https://github.com/unjs/node-fetch-native)
+- `get-set-cookie`: [`Headers.prototype.getSetCookie`](https://github.com/whatwg/fetch/pull/1346)

--- a/packages/polyfills/src/get-set-cookie.test.ts
+++ b/packages/polyfills/src/get-set-cookie.test.ts
@@ -1,0 +1,32 @@
+import { test, expect, describe, beforeAll } from "vitest";
+import install from "./get-set-cookie";
+
+describe("Headers.prototype.getSetCookie", () => {
+  beforeAll(async () => {
+    if (!globalThis.Headers) {
+      await import("./node-fetch").then((nf) => nf.default());
+    }
+    install();
+  });
+
+  test("can retrieve multiple set-cookie headers", () => {
+    const h = new Headers();
+    h.append("Set-Cookie", "a=1");
+    h.append("Set-Cookie", "b=2");
+    expect(h.getSetCookie()).toEqual(["a=1", "b=2"]);
+  });
+
+  test("can delete set-cookie headers", () => {
+    const h = new Headers();
+    h.append("Set-Cookie", "a=1");
+    h.delete("Set-Cookie");
+    expect(h.getSetCookie()).toEqual([]);
+  });
+
+  test("can reset set-cookie headers", () => {
+    const h = new Headers();
+    h.append("Set-Cookie", "a=1");
+    h.set("Set-Cookie", "b=2");
+    expect(h.getSetCookie()).toEqual(["b=2"]);
+  });
+});

--- a/packages/polyfills/src/get-set-cookie.ts
+++ b/packages/polyfills/src/get-set-cookie.ts
@@ -1,0 +1,120 @@
+import type {} from "@hattip/core";
+
+const SET_COOKIE = Symbol("set-cookie");
+
+declare global {
+  interface Headers {
+    [SET_COOKIE]?: string[];
+    raw?(): Record<string, string | string[]>;
+    getAll?(name: string): string[];
+  }
+}
+
+export default function install() {
+  if (typeof globalThis.Headers.prototype.getSetCookie === "function") {
+    return;
+  }
+
+  if (typeof globalThis.Headers.prototype.getAll === "function") {
+    globalThis.Headers.prototype.getSetCookie = function () {
+      return this.getAll!("Set-Cookie");
+    };
+
+    return;
+  }
+
+  if (typeof globalThis.Headers.prototype.raw === "function") {
+    globalThis.Headers.prototype.getSetCookie = function () {
+      const setCookie = this.raw!()["set-cookie"];
+      if (!setCookie) {
+        return [];
+      } else if (typeof setCookie === "string") {
+        return [setCookie];
+      }
+
+      return setCookie;
+    };
+
+    return;
+  }
+
+  globalThis.Headers.prototype.getSetCookie = function getSetCookie() {
+    return this[SET_COOKIE] || [];
+  };
+
+  const originalAppend = globalThis.Headers.prototype.append;
+  globalThis.Headers.prototype.append = function append(
+    name: string,
+    value: string,
+  ) {
+    if (name.toLowerCase() === "set-cookie") {
+      if (!this[SET_COOKIE]) {
+        this[SET_COOKIE] = [];
+      }
+
+      this[SET_COOKIE].push(value);
+    }
+
+    return originalAppend.call(this, name, value);
+  };
+
+  const originalDelete = globalThis.Headers.prototype.delete;
+  globalThis.Headers.prototype.delete = function deleteHeader(name: string) {
+    if (name.toLowerCase() === "set-cookie") {
+      this[SET_COOKIE] = [];
+    }
+
+    return originalDelete.call(this, name);
+  };
+
+  const originalSet = globalThis.Headers.prototype.set;
+  globalThis.Headers.prototype.set = function setHeader(
+    name: string,
+    value: string,
+  ) {
+    if (name.toLowerCase() === "set-cookie") {
+      this[SET_COOKIE] = [value];
+    }
+
+    return originalSet.call(this, name, value);
+  };
+
+  const Headers = class extends globalThis.Headers {
+    constructor(init?: HeadersInit) {
+      super(init);
+      if (!init) {
+        return;
+      }
+      if (init instanceof Headers || init instanceof Headers) {
+        this[SET_COOKIE] = init[SET_COOKIE];
+      } else if (Array.isArray(init)) {
+        this[SET_COOKIE] = init
+          .filter(([key]) => key.toLowerCase() === "set-cookie")
+          .map(([, value]) => value);
+      } else {
+        this[SET_COOKIE] = [];
+        for (const [key, value] of Object.entries(init)) {
+          if (key.toLowerCase() === "set-cookie") {
+            if (typeof value === "string") {
+              this[SET_COOKIE]!.push(value);
+            } else if (Array.isArray(value)) {
+              this[SET_COOKIE]!.push(...(value as string[]));
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const Response = class extends globalThis.Response {
+    constructor(body: any, init?: ResponseInit) {
+      super(body, init);
+      if (init && init.headers) {
+        this.headers[SET_COOKIE] = new Headers(init.headers)[SET_COOKIE];
+      }
+    }
+  };
+
+  globalThis.Headers = Headers;
+  globalThis.Response = Response;
+}

--- a/packages/polyfills/src/node-fetch.ts
+++ b/packages/polyfills/src/node-fetch.ts
@@ -1,0 +1,29 @@
+import * as nodeFetch from "node-fetch-native";
+import { Readable } from "stream";
+
+export default function install() {
+  globalThis.fetch = globalThis.fetch ?? nodeFetch.default;
+  globalThis.AbortController =
+    globalThis.AbortController ?? nodeFetch.AbortController;
+  globalThis.Blob = globalThis.Blob ?? nodeFetch.Blob;
+  globalThis.File = globalThis.File ?? nodeFetch.File;
+  globalThis.FormData = globalThis.FormData ?? nodeFetch.FormData;
+  globalThis.Headers = globalThis.Headers ?? nodeFetch.Headers;
+  globalThis.Request = globalThis.Request ?? nodeFetch.Request;
+
+  if (globalThis.Response) return;
+
+  // node-fetch doesn't allow constructing a Request from ReadableStream
+  // see: https://github.com/node-fetch/node-fetch/issues/1096
+  class Response extends nodeFetch.Response {
+    constructor(input: BodyInit, init?: ResponseInit) {
+      if (input instanceof ReadableStream) {
+        input = Readable.from(input as any) as any;
+      }
+
+      super(input as any, init);
+    }
+  }
+
+  globalThis.Response = Response as any;
+}

--- a/packages/polyfills/tsconfig.json
+++ b/packages/polyfills/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Node"
+  }
+}

--- a/packages/polyfills/tsup.config.ts
+++ b/packages/polyfills/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: ["./src/node-fetch.ts", "./src/get-set-cookie.ts"],
+    format: ["esm", "cjs"],
+    platform: "node",
+    target: "node14",
+    dts: true,
+  },
+]);

--- a/packages/router/index.d.ts
+++ b/packages/router/index.d.ts
@@ -1,4 +1,4 @@
-/// reference types="./ambient.d.ts" />
+/// <reference types="./ambient.d.ts" />
 
 export { default } from "./dist";
 export * from "./dist";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,7 @@ importers:
       '@cyco130/eslint-config': ^2.0.0
       '@hattip/adapter-node': workspace:*
       '@hattip/core': workspace:*
+      '@hattip/polyfills': workspace:*
       '@types/node': ^18.0.0
       eslint: ^8.18.0
       netlify-lambda-types: ^1.0.0
@@ -93,6 +94,7 @@ importers:
     dependencies:
       '@hattip/adapter-node': link:../adapter-node
       '@hattip/core': link:../core
+      '@hattip/polyfills': link:../polyfills
       netlify-lambda-types: 1.0.0
     devDependencies:
       '@cyco130/eslint-config': 2.0.0_b5e7v2qnwxfo6hmiq56u52mz3e
@@ -106,18 +108,19 @@ importers:
     specifiers:
       '@cyco130/eslint-config': ^2.0.0
       '@hattip/core': workspace:*
+      '@hattip/polyfills': workspace:*
       '@types/node': ^18.0.0
       eslint: ^8.18.0
-      node-fetch: ^3.2.6
       publint: ^0.1.1
       tsup: ^6.1.2
       typescript: ^4.7.4
+    dependencies:
+      '@hattip/core': link:../core
+      '@hattip/polyfills': link:../polyfills
     devDependencies:
       '@cyco130/eslint-config': 2.0.0_b5e7v2qnwxfo6hmiq56u52mz3e
-      '@hattip/core': link:../core
       '@types/node': 18.0.0
       eslint: 8.18.0
-      node-fetch: 3.2.6
       publint: 0.1.1
       tsup: 6.1.2_typescript@4.7.4
       typescript: 4.7.4
@@ -268,6 +271,29 @@ importers:
 
   packages/hattip:
     specifiers: {}
+
+  packages/polyfills:
+    specifiers:
+      '@cyco130/eslint-config': ^2.0.0
+      '@hattip/core': workspace:*
+      '@types/node': ^18.0.0
+      eslint: ^8.18.0
+      node-fetch-native: ^0.1.4
+      publint: ^0.1.1
+      tsup: ^6.1.2
+      typescript: ^4.7.4
+      vitest: ^0.15.2
+    dependencies:
+      '@hattip/core': link:../core
+      node-fetch-native: 0.1.4
+    devDependencies:
+      '@cyco130/eslint-config': 2.0.0_b5e7v2qnwxfo6hmiq56u52mz3e
+      '@types/node': 18.0.0
+      eslint: 8.18.0
+      publint: 0.1.1
+      tsup: 6.1.2_typescript@4.7.4
+      typescript: 4.7.4
+      vitest: 0.15.2
 
   packages/router:
     specifiers:
@@ -7280,6 +7306,10 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     dev: true
+
+  /node-fetch-native/0.1.4:
+    resolution: {integrity: sha512-10EKpOCQPXwZVFh3U1ptOMWBgKTbsN7Vvo6WVKt5pw4hp8zbv6ZVBZPlXw+5M6Tyi1oc1iD4/sNPd71KYA16tQ==}
+    dev: false
 
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ HatTip is extremely modular so you can use as little or as much as you need:
   - [`bundler-vercel`](./packages/bundler-vercel): Bundler for Vercel edge and serverless functions
   - [`bundler-netlify`](./packages/bundler-netlify): Bundler for Netlify edge and Netlify functions
   - [`bundler-deno`](./packages/bundler-deno): Bundler for Deno
+- [`polyfills](./packages/polyfills): A collection of polyfills used by adapters for compatibility across platforms
 - [`compose`](./packages/compose): A middleware system for combining multiple handlers into a single one
 - [`router`](./packages/router): Express-style imperative router
 


### PR DESCRIPTION
This PR implements a `@hattip/polyfills` package 

- Closes #11 by implementing and using `Headers.prototype.getSetCookie()`
- Improves and refactors `node-fetch` polyfill