### PR TITLE
chore: always prefer ipv4 in CI tests

### DIFF
--- a/testbed/basic/entry-node-native-fetch.js
+++ b/testbed/basic/entry-node-native-fetch.js
@@ -10,6 +10,6 @@ const app = connect();
 app.use(sirv("public"));
 app.use(createMiddleware(handler));
 
-createServer(app).listen(3000, "localhost", () => {
-  console.log("Server listening on http://localhost:3000");
+createServer(app).listen(3000, "127.0.0.1", () => {
+  console.log("Server listening on http://127.0.0.1:3000");
 });

--- a/testbed/basic/entry-node.js
+++ b/testbed/basic/entry-node.js
@@ -10,6 +10,6 @@ const app = connect();
 app.use(sirv("public"));
 app.use(createMiddleware(handler));
 
-createServer(app).listen(3000, "localhost", () => {
-  console.log("Server listening on http://localhost:3000");
+createServer(app).listen(3000, "127.0.0.1", () => {
+  console.log("Server listening on http://127.0.0.1:3000");
 });

--- a/testbed/basic/readme.md
+++ b/testbed/basic/readme.md
@@ -2,7 +2,7 @@
 
 ## Running
 
-When the environment variable `CI` equals `true`, `pnpm run ci` will all the automatic tests. When the environment variable `CI` does not equal `true`, `pnpm run ci` will run its tests on an already running server. You can set the server address by setting the environment variable `TEST_HOST` which defaults to `http://localhost:3000`.
+When the environment variable `CI` equals `true`, `pnpm run ci` will all the automatic tests. When the environment variable `CI` does not equal `true`, `pnpm run ci` will run its tests on an already running server. You can set the server address by setting the environment variable `TEST_HOST` which defaults to `http://127.0.0.1:3000`.
 
 ## Status
 


### PR DESCRIPTION
Closes #10 by always using IPv4 in CI tests.

Node 18 prefers IPv6 when resolving `localhost` but Deno doesn't bind to IPv6 by default which was causing some tests to fail.