### PR TITLE
chore: fix Windows build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "hattip-workspace-root",
   "private": "true",
   "scripts": {
-    "dev": "pnpm -r --parallel --filter='./packages/*/*' run dev",
-    "build": "pnpm -r --filter='./packages/*/*' run build",
+    "dev": "pnpm -r --parallel --filter=\"./packages/*/*\" run dev",
+    "build": "pnpm -r --filter=\"./packages/*/*\" run build",
     "prepare": "husky install",
     "precommit": "lint-staged",
     "test": "pnpm run test:prettier && pnpm run test:packages && pnpm run ci",


### PR DESCRIPTION
Fixes #9: Build was failing because of the use of single quotes in `pnpm --filter`.