### PR TITLE
docs(bundler-deno): update deno link in the readme

### DIFF
--- a/packages/bundler/bundler-deno/readme.md
+++ b/packages/bundler/bundler-deno/readme.md
@@ -1,6 +1,6 @@
 # `@hattip/bundler-deno`
 
-HatTip bundler for [Deno](https://workers.cloudflare.com). It uses [`esbuild`](https://esbuild.github.io) behind the scenes.
+HatTip bundler for [Deno](https://deno.land). It uses [`esbuild`](https://esbuild.github.io) behind the scenes.
 
 ## CLI
 


### PR DESCRIPTION
The link was pointing to Cloudflare.
Update it accordingly to link to the Deno website.