### PR TITLE
feat: add uWebSockets.js adapter

### DIFF
--- a/packages/adapter/adapter-node/readme.md
+++ b/packages/adapter/adapter-node/readme.md
@@ -79,7 +79,7 @@ interface NodeAdapterOptions {
 
 ## Using native `fetch`
 
-This adapter uses [`node-fetch`](https://github.com/node-fetch/node-fetch) as its `fetch` implementation. Node versions since 16.15, 17.5, and 18 have a native implementation behind the `--experimental-fetch` flag. You can opt in for the native implementation by importing your adapter from `@hattip/adapter-node/native-fetch`.
+This adapter uses [`node-fetch`](https://github.com/node-fetch/node-fetch) if the `fetch` global is not available. You can disable this behavior by importing your adapter from `@hattip/adapter-node/native-fetch`, which will throw an error if `fetch` is not available.
 
 ## `context.passThrough` behavior
 

--- a/packages/adapter/adapter-uwebsockets/.eslintrc.cjs
+++ b/packages/adapter/adapter-uwebsockets/.eslintrc.cjs
@@ -1,0 +1,14 @@
+require("@cyco130/eslint-config/patch");
+
+module.exports = {
+	root: true,
+	extends: ["@cyco130/eslint-config/node"], // or react instead of node
+	parserOptions: { tsconfigRootDir: __dirname },
+	settings: {
+		"import/resolver": {
+			typescript: {
+				project: [__dirname + "/tsconfig.json"],
+			},
+		},
+	},
+};

--- a/packages/adapter/adapter-uwebsockets/LICENSE
+++ b/packages/adapter/adapter-uwebsockets/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2021 Fatih Aygün and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/adapter/adapter-uwebsockets/lint-staged.config.mjs
+++ b/packages/adapter/adapter-uwebsockets/lint-staged.config.mjs
@@ -1,0 +1,8 @@
+export default {
+	"**/*.ts?(x)": [
+		() => "tsc -p tsconfig.json --noEmit",
+		"eslint --max-warnings 0 --ignore-pattern dist",
+		"vitest related --run",
+	],
+	"*": "prettier --ignore-unknown --write",
+};

--- a/packages/adapter/adapter-uwebsockets/package.json
+++ b/packages/adapter/adapter-uwebsockets/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@hattip/adapter-uwebsockets",
+  "version": "0.0.28",
+  "type": "module",
+  "description": "uWebSockets.js adapter for Hattip",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./native-fetch": "./dist/native-fetch.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*.d.ts"
+      ]
+    }
+  },
+  "author": "Fatih Aygün <cyco130@gmail.com>",
+  "repository": "https://github.com/hattipjs/hattip",
+  "license": "MIT",
+  "scripts": {
+    "build": "rimraf dist && tsup",
+    "dev": "tsup --watch",
+    "prepack": "pnpm build",
+    "test": "pnpm test:typecheck && pnpm test:lint && pnpm test:package",
+    "test:typecheck": "tsc -p tsconfig.json --noEmit",
+    "test:lint": "eslint . --max-warnings 0 --ignore-pattern dist",
+    "test:package": "publint"
+  },
+  "devDependencies": {
+    "@cyco130/eslint-config": "^2.1.3",
+    "@types/node": "^18.14.0",
+    "eslint": "^8.34.0",
+    "publint": "^0.1.9",
+    "tsup": "^6.6.3",
+    "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "@hattip/core": "workspace:*",
+    "@hattip/polyfills": "workspace:*",
+    "mrmime": "^1.0.1",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.19.0"
+  }
+}

--- a/packages/adapter/adapter-uwebsockets/readme.md
+++ b/packages/adapter/adapter-uwebsockets/readme.md
@@ -1,0 +1,73 @@
+# `@hattip/adapter-uwebsockets`
+
+HatTip adapter for [uWebSockets.js](https://github.com/uNetworking/uWebSockets.js) on Node.js.
+
+## Usage
+
+```js
+import { createServer } from "@hattip/adapter-uwebsockets";
+import handler from "./handler.js";
+
+createServer(handler).listen(3000, "localhost", () => {
+  console.log("Server listening on http://localhost:3000");
+});
+```
+
+## API
+
+```ts
+/**
+ * Create an HTTP server
+ */
+function createServer(
+  handler: Handler,
+  adapterOptions?: UWebSocketsAdapterOptions,
+  appOptions?: appOptions,
+): TemlateApp;
+
+/** Adapter options */
+export interface UWebSocketAdapterOptions {
+  /**
+   * Set the origin part of the URL to a constant value.
+   * It defaults to `process.env.ORIGIN`. If neither is set,
+   * the origin is computed from the protocol and hostname.
+   * To determine the protocol, `req.protocol` is tried first.
+   * If `trustProxy` is set, `X-Forwarded-Proto` header is used.
+   * Otherwise, `req.socket.encrypted` is used.
+   * To determine the hostname, `X-Forwarded-Host`
+   * (if `trustProxy` is set) or `Host` header is used.
+   */
+  origin?: string;
+  /**
+   * Whether to trust `X-Forwarded-*` headers. `X-Forwarded-Proto`
+   * and `X-Forwarded-Host` are used to determine the origin when
+   * `origin` and `process.env.ORIGIN` are not set. `X-Forwarded-For`
+   * is used to determine the IP address. The leftmost values are used
+   * if multiple values are set. Defaults to true if `process.env.TRUST_PROXY`
+   * is set to `1`, otherwise false.
+   */
+  trustProxy?: boolean;
+  /** Use SSL (https) */
+  ssl?: boolean;
+  /** Static file directory */
+  staticDir?: string;
+  /**
+   * Callback to configure the uWebSockets.js app.
+   * Useful for adding WebSocket or HTTP routes before the HatTip handler
+   * is added.
+   */
+  configureServer?: (app: TemplatedApp) => void;
+}
+```
+
+## Limitations
+
+This adapter is experimental. In particular, the static file server is very limited at the moment.
+
+## Using native `fetch`
+
+This adapter uses [`node-fetch`](https://github.com/node-fetch/node-fetch) if the `fetch` global is not available. You can disable this behavior by importing your adapter from `@hattip/adapter-uwebsockets/native-fetch`, which will throw an error if `fetch` is not available.
+
+## `context.platform`
+
+This adapter makes uWebSockets.js `request` (`HTTPRequest`) and `response` (`HTTPResponse`) objects available in `context.platform`.

--- a/packages/adapter/adapter-uwebsockets/src/common.ts
+++ b/packages/adapter/adapter-uwebsockets/src/common.ts
@@ -1,0 +1,275 @@
+import type { HattipHandler } from "@hattip/core";
+import {
+	App,
+	HttpRequest,
+	HttpResponse,
+	AppOptions,
+	SSLApp,
+	TemplatedApp,
+} from "uWebSockets.js";
+import { scanDir } from "./static-server";
+import fs from "fs";
+import { lookup } from "mrmime";
+
+/** Adapter options */
+export interface UWebSocketAdapterOptions {
+	/**
+	 * Set the origin part of the URL to a constant value.
+	 * It defaults to `process.env.ORIGIN`. If neither is set,
+	 * the origin is computed from the protocol and hostname.
+	 * To determine the protocol, `req.protocol` is tried first.
+	 * If `trustProxy` is set, `X-Forwarded-Proto` header is used.
+	 * Otherwise, `req.socket.encrypted` is used.
+	 * To determine the hostname, `X-Forwarded-Host`
+	 * (if `trustProxy` is set) or `Host` header is used.
+	 */
+	origin?: string;
+	/**
+	 * Whether to trust `X-Forwarded-*` headers. `X-Forwarded-Proto`
+	 * and `X-Forwarded-Host` are used to determine the origin when
+	 * `origin` and `process.env.ORIGIN` are not set. `X-Forwarded-For`
+	 * is used to determine the IP address. The leftmost values are used
+	 * if multiple values are set. Defaults to true if `process.env.TRUST_PROXY`
+	 * is set to `1`, otherwise false.
+	 */
+	trustProxy?: boolean;
+	/** Use SSL (https) */
+	ssl?: boolean;
+	/** Static file directory */
+	staticDir?: string;
+	/**
+	 * Callback to configure the uWebSockets.js app.
+	 * Useful for adding WebSocket or HTTP routes before the HatTip handler
+	 * is added.
+	 */
+	configureServer?: (app: TemplatedApp) => void;
+}
+
+export interface UWebSocketPlatformInfo {
+	request: HttpRequest;
+	response: HttpResponse;
+}
+
+/**
+ * Create an HTTP server
+ */
+export function createServer(
+	handler: HattipHandler,
+	adapterOptions?: UWebSocketAdapterOptions,
+	appOptions?: AppOptions,
+) {
+	const {
+		origin = process.env.ORIGIN,
+		trustProxy = process.env.TRUST_PROXY === "1",
+		ssl = false,
+		staticDir,
+		configureServer,
+	} = adapterOptions || {};
+
+	const files = staticDir ? new Set(scanDir(staticDir, staticDir)) : undefined;
+
+	let { protocol, host } = origin
+		? new URL(origin)
+		: ({} as Record<string, undefined>);
+
+	if (protocol) {
+		protocol = protocol.slice(0, -1);
+	}
+
+	if (ssl && !appOptions) {
+		throw new Error("SSL requires appOptions");
+	}
+
+	const app = ssl ? SSLApp(appOptions!) : appOptions ? App(appOptions) : App();
+
+	configureServer?.(app);
+
+	return app.any("/*", (res, req) => {
+		let aborted = false;
+		res.onAborted(() => (aborted = true));
+
+		const method = req.getCaseSensitiveMethod();
+		const path = req.getUrl();
+
+		// TODO: Create a better static file server
+		if (
+			files &&
+			method === "GET" &&
+			(files.has(path) || files.has(path + "/index.html"))
+		) {
+			const fileStream = fs.createReadStream(
+				staticDir + (files.has(path) ? path : path + "/index.html"),
+			);
+
+			res.writeStatus("200 OK");
+			const contentType = lookup(path);
+			if (contentType) {
+				res.writeHeader("Content-Type", contentType);
+			}
+
+			fileStream.on("data", (chunk) => {
+				if (!aborted) {
+					res.write(chunk);
+				}
+			});
+
+			fileStream.on("end", () => {
+				if (!aborted) {
+					res.end();
+				}
+			});
+
+			return;
+		}
+
+		const headers = new Headers();
+		req.forEach((key, value) => headers.append(key, value));
+
+		function getForwardedHeader(name: string) {
+			return (headers.get("x-forwarded-" + name) || "").split(",", 1)[0].trim();
+		}
+
+		protocol =
+			protocol ||
+			(trustProxy && getForwardedHeader("proto")) ||
+			(ssl && "https") ||
+			"http";
+
+		const ipAddress = ipAddressBytesToString(res.getRemoteAddress());
+
+		host =
+			host ||
+			(trustProxy && getForwardedHeader("host")) ||
+			headers.get("host") ||
+			ipAddress;
+
+		if (!host) {
+			console.warn(
+				"Could not automatically determine the origin host, using 'localhost'. " +
+					"Use the 'origin' option or the 'ORIGIN' environment variable to set the origin explicitly.",
+			);
+			host = "localhost";
+		}
+
+		const ip = (trustProxy && getForwardedHeader("for")) || ipAddress || "";
+
+		const query = req.getQuery();
+		const url = protocol + "://" + host + path + (query ? "?" + query : "");
+
+		const responseOrPromise = handler({
+			ip,
+			passThrough() {
+				/* Do nothing */
+			},
+			waitUntil() {
+				/* Do nothing */
+			},
+			platform: {
+				request: req,
+				response: res,
+			},
+			request: new Request(url, {
+				method,
+				headers,
+				body:
+					method === "GET" || method === "HEAD"
+						? undefined
+						: new ReadableStream({
+								start(controller) {
+									res.onData((chunk, isLast) => {
+										const buffer = Buffer.from(chunk);
+										controller.enqueue(buffer);
+										if (isLast) controller.close();
+									});
+								},
+						  }),
+				// @ts-expect-error: Node requires this for streams
+				duplex: "half",
+			}),
+		});
+
+		if (responseOrPromise instanceof Promise) {
+			responseOrPromise.then(finish);
+		} else {
+			finish(responseOrPromise);
+		}
+
+		async function finish(response: Response) {
+			if (aborted) return;
+
+			res.writeStatus(
+				`${response.status}${
+					response.statusText ? " " + response.statusText : ""
+				}`,
+			);
+
+			response.headers.forEach((value, key) => {
+				if (key === "set-cookie") {
+					const values = response.headers.getSetCookie();
+					for (const value of values) {
+						res.writeHeader(key, value);
+					}
+				} else {
+					res.writeHeader(key, value);
+				}
+			});
+
+			if (response.body) {
+				const reader = (response.body as any as AsyncIterable<Buffer | string>)[
+					Symbol.asyncIterator
+				]();
+
+				const first = await reader.next();
+				if (first.done) {
+					res.end();
+				} else {
+					const secondPromise = reader.next();
+					let second = await Promise.race([
+						secondPromise,
+						Promise.resolve(null),
+					]);
+
+					if (second && second.done) {
+						res.end(first.value);
+					} else {
+						res.write(first.value);
+						second = await secondPromise;
+						for (; !second.done; second = await reader.next()) {
+							res.write(Buffer.from(second.value));
+						}
+						res.end();
+					}
+				}
+			} else {
+				res.end();
+			}
+		}
+	});
+}
+
+// Convert 4 or 16 bytes to an IPv4 or IPv6 string
+function ipAddressBytesToString(bytes: ArrayBuffer) {
+	let view = new DataView(bytes);
+	let result = "";
+	if (
+		view.byteLength === 16 &&
+		view.getUint32(0) === 0 &&
+		view.getUint32(4) === 0 &&
+		view.getUint32(8) === 0x0000ffff
+	) {
+		view = new DataView(bytes, 12);
+	}
+
+	if (view.byteLength === 4) {
+		for (let i = 0; i < 4; i++) {
+			result += view.getUint8(i);
+			if (i < 3) result += ".";
+		}
+	} else if (view.byteLength === 16) {
+		for (let i = 0; i < 16; i += 2) {
+			result += view.getUint16(i).toString(16);
+			if (i < 14) result += ":";
+		}
+	}
+	return result;
+}

--- a/packages/adapter/adapter-uwebsockets/src/index.ts
+++ b/packages/adapter/adapter-uwebsockets/src/index.ts
@@ -1,0 +1,14 @@
+import installNodeFetch from "@hattip/polyfills/node-fetch";
+import installGetSetCookie from "@hattip/polyfills/get-set-cookie";
+import installCrypto from "@hattip/polyfills/crypto";
+
+installNodeFetch();
+installGetSetCookie();
+installCrypto();
+
+export type {
+	UWebSocketAdapterOptions,
+	UWebSocketPlatformInfo,
+} from "./common";
+
+export { createServer } from "./common";

--- a/packages/adapter/adapter-uwebsockets/src/native-fetch.ts
+++ b/packages/adapter/adapter-uwebsockets/src/native-fetch.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line import/no-unresolved
+import * as webStream from "stream/web";
+import installGetSetCookie from "@hattip/polyfills/get-set-cookie";
+import installCrypto from "@hattip/polyfills/crypto";
+import installHalfDuplexRequest from "@hattip/polyfills/half-duplex-request";
+
+installGetSetCookie();
+installCrypto();
+installHalfDuplexRequest();
+
+for (const key of Object.keys(webStream)) {
+	if (!(key in global)) {
+		(global as any)[key] = (webStream as any)[key];
+	}
+}
+
+export type {
+	UWebSocketAdapterOptions,
+	UWebSocketPlatformInfo,
+} from "./common";
+
+export { createServer } from "./common";

--- a/packages/adapter/adapter-uwebsockets/src/static-server.ts
+++ b/packages/adapter/adapter-uwebsockets/src/static-server.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+
+export function scanDir(dir: string, root: string): string[] {
+	const files = fs.readdirSync(dir);
+	const result: string[] = [];
+	for (const file of files) {
+		const path = `${dir}/${file}`;
+		const stat = fs.statSync(path);
+		if (stat.isDirectory()) {
+			result.push(...scanDir(path, root));
+		} else {
+			result.push(path.replace(/\\/g, "/").slice(root.length));
+		}
+	}
+
+	return result;
+}

--- a/packages/adapter/adapter-uwebsockets/tsconfig.json
+++ b/packages/adapter/adapter-uwebsockets/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "es2020",
+		"module": "ESNext",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"moduleResolution": "Node"
+	}
+}

--- a/packages/adapter/adapter-uwebsockets/tsup.config.ts
+++ b/packages/adapter/adapter-uwebsockets/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+	{
+		entry: ["./src/index.ts", "./src/native-fetch.ts"],
+		format: ["esm"],
+		platform: "node",
+		target: "node14",
+		dts: true,
+	},
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,31 @@ importers:
       tsup: 6.6.3_typescript@4.9.5
       typescript: 4.9.5
 
+  packages/adapter/adapter-uwebsockets:
+    specifiers:
+      '@cyco130/eslint-config': ^2.1.3
+      '@hattip/core': workspace:*
+      '@hattip/polyfills': workspace:*
+      '@types/node': ^18.14.0
+      eslint: ^8.34.0
+      mrmime: ^1.0.1
+      publint: ^0.1.9
+      tsup: ^6.6.3
+      typescript: ^4.9.5
+      uWebSockets.js: github:uNetworking/uWebSockets.js#v20.19.0
+    dependencies:
+      '@hattip/core': link:../../base/core
+      '@hattip/polyfills': link:../../base/polyfills
+      mrmime: 1.0.1
+      uWebSockets.js: github.com/uNetworking/uWebSockets.js/42c9c0d5d31f46ca4115dc75672b0037ec970f28
+    devDependencies:
+      '@cyco130/eslint-config': 2.1.3_7kw3g6rralp5ps6mg3uyzz6azm
+      '@types/node': 18.14.0
+      eslint: 8.34.0
+      publint: 0.1.9
+      tsup: 6.6.3_typescript@4.9.5
+      typescript: 4.9.5
+
   packages/adapter/adapter-vercel-edge:
     specifiers:
       '@cyco130/eslint-config': ^2.1.3
@@ -556,6 +581,7 @@ importers:
       '@hattip/adapter-netlify-edge': workspace:*
       '@hattip/adapter-netlify-functions': workspace:*
       '@hattip/adapter-node': workspace:*
+      '@hattip/adapter-uwebsockets': workspace:*
       '@hattip/adapter-vercel-edge': workspace:*
       '@hattip/bundler-cloudflare-workers': workspace:*
       '@hattip/bundler-deno': workspace:*
@@ -606,6 +632,7 @@ importers:
       '@hattip/adapter-lagon': link:../../packages/adapter/adapter-lagon
       '@hattip/adapter-netlify-edge': link:../../packages/adapter/adapter-netlify-edge
       '@hattip/adapter-netlify-functions': link:../../packages/adapter/adapter-netlify-functions
+      '@hattip/adapter-uwebsockets': link:../../packages/adapter/adapter-uwebsockets
       '@hattip/adapter-vercel-edge': link:../../packages/adapter/adapter-vercel-edge
       '@hattip/bundler-cloudflare-workers': link:../../packages/bundler/bundler-cloudflare-workers
       '@hattip/bundler-deno': link:../../packages/bundler/bundler-deno
@@ -4318,7 +4345,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
 
   /call-me-maybe/1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
@@ -6743,20 +6770,12 @@ packages:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
     dev: true
 
-  /get-intrinsic/1.1.3:
-    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
-    dependencies:
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.3
-
   /get-intrinsic/1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
-    dev: true
 
   /get-port/5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
@@ -9354,12 +9373,8 @@ packages:
       kind-of: 3.2.2
     dev: true
 
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
-
   /object-inspect/1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
-    dev: true
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -10824,8 +10839,8 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
-      object-inspect: 1.12.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
 
   /siginfo/2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -12535,3 +12550,9 @@ packages:
       compress-commons: 4.1.1
       readable-stream: 3.6.0
     dev: true
+
+  github.com/uNetworking/uWebSockets.js/42c9c0d5d31f46ca4115dc75672b0037ec970f28:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/42c9c0d5d31f46ca4115dc75672b0037ec970f28}
+    name: uWebSockets.js
+    version: 20.19.0
+    dev: false

--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ HatTip is extremely modular so you can use as little or as much as you need:
   - [`adapter-deno`](./packages/adapter/adapter-deno): Deno
   - [`adapter-bun`](./packages/adapter/adapter-bun): Bun
   - [`adapter-lagon`](./packages/adapter/adapter-lagon): Lagon
+  - [`adapter-uwebsockets`](./packages/adapter/adapter-uwebsockets): uWebSockets.js
 - **Bundlers:** Worker and serverless platforms usually require your code to be in bundled form. These packages provide bundlers fine-tuned for their respective platforms:
   - [`bundler-cloudflare-workers`](./packages/bundler/bundler-cloudflare-workers): Cloudflare Workers
   - [`bundler-vercel`](./packages/bundler/bundler-vercel): Vercel edge and serverless functions

--- a/testbed/basic/bench.js
+++ b/testbed/basic/bench.js
@@ -1,0 +1,10 @@
+run().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});
+
+async function run() {
+	for (let i = 0; i < 10_000; i++) {
+		await fetch("http://localhost:3000/");
+	}
+}

--- a/testbed/basic/ci.test.ts
+++ b/testbed/basic/ci.test.ts
@@ -40,6 +40,13 @@ if (process.env.CI === "true") {
 		);
 	}
 
+	const uwsAvailable = nodeVersionMajor >= 18 && process.platform === "linux";
+	if (!uwsAvailable) {
+		console.warn(
+			"Node version < 18 or not on Linux, will skip uWebSockets.js tests",
+		);
+	}
+
 	cases = [
 		{
 			name: "Node with node-fetch",
@@ -75,6 +82,10 @@ if (process.env.CI === "true") {
 			name: "Deno",
 			command:
 				"pnpm build:deno && deno run --allow-read --allow-net --allow-env dist/deno/index.js",
+		},
+		uwsAvailable && {
+			name: "uWebSockets.js",
+			command: "node entry-uws.js",
 		},
 	].filter(Boolean) as typeof cases;
 	host = "http://127.0.0.1:3000";

--- a/testbed/basic/entry-uws.js
+++ b/testbed/basic/entry-uws.js
@@ -1,0 +1,14 @@
+// @ts-check
+import { createServer } from "@hattip/adapter-uwebsockets";
+import handler from "./index.js";
+
+createServer(handler, {
+	staticDir: "./public",
+}).listen(3000, (success) => {
+	if (!success) {
+		console.error("Failed to listen on port 3000");
+		process.exit(1);
+	}
+
+	console.log("Server listening on http://127.0.0.1:3000");
+});

--- a/testbed/basic/index.js
+++ b/testbed/basic/index.js
@@ -9,11 +9,11 @@ const app = createRouter();
 
 app.use(cookie());
 
-app.get("/", (ctx) =>
-	html(
+app.get("/", (ctx) => {
+	return html(
 		`<h1>Hello from Hattip!</h1><p>URL: <span>${ctx.request.url}</span></p><p>Your IP address is: <span>${ctx.ip}</span></p>`,
-	),
-);
+	);
+});
 
 app.get(
 	"/binary",

--- a/testbed/basic/package.json
+++ b/testbed/basic/package.json
@@ -20,6 +20,7 @@
     "@hattip/adapter-lagon": "workspace:*",
     "@hattip/adapter-netlify-edge": "workspace:*",
     "@hattip/adapter-netlify-functions": "workspace:*",
+    "@hattip/adapter-uwebsockets": "workspace:*",
     "@hattip/adapter-vercel-edge": "workspace:*",
     "@hattip/bundler-cloudflare-workers": "workspace:*",
     "@hattip/bundler-deno": "workspace:*",

--- a/testbed/basic/readme.md
+++ b/testbed/basic/readme.md
@@ -4,6 +4,8 @@
 
 When the environment variable `CI` equals `true`, `pnpm run ci` will all the automatic tests. When the environment variable `CI` does not equal `true`, `pnpm run ci` will run its tests on an already running server. You can set the server address by setting the environment variable `TEST_HOST` which defaults to `http://127.0.0.1:3000`.
 
+To manually test streaming, run `curl -ND - 'http://127.0.0.1:3000/bin-stream?delay=50'` and observe the typewriter effect.
+
 ## Status
 
 ### Node.js with `node-fetch`


### PR DESCRIPTION
This PR adds a [uWebSocket.js](https://github.com/uNetworking/uWebSockets.js/) adapter.

It is supposed to be a very fast WebSocket and PubSub server with very low resource consumption but it also supports plain HTTP. A simple benchmark with a simple HTML response shows that it does perform better than Node's native HTTP module, but only marginally.

I have not compared the WebSocket performance (but it does work).