### PR TITLE
add: MIT license to `adapter-test` package

### DIFF
--- a/packages/adapter/adapter-test/LICENSE
+++ b/packages/adapter/adapter-test/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2022 Tessei Kameyama, Fatih Aygün and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/adapter/adapter-test/package.json
+++ b/packages/adapter/adapter-test/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@hattip/adapter-test",
   "version": "0.0.29",
-  "private": true,
   "type": "module",
   "description": "Testing utility for HatTip",
   "files": [
@@ -33,13 +32,13 @@
   },
   "devDependencies": {
     "@cyco130/eslint-config": "^2.1.2",
-    "@types/set-cookie-parser": "^2.4.2",
     "eslint": "^8.26.0",
     "publint": "^0.1.9",
     "tsup": "^6.6.3",
     "typescript": "^4.8.4",
     "vitest": "^0.24.3"
   },
-  "author": "Tessei Kameyama",
-  "repository": "https://github.com/hattipjs/hattip"
+  "author": "Tessei Kameyama <tkamenoko@vivaldi.net>",
+  "repository": "https://github.com/hattipjs/hattip",
+  "license": "MIT"
 }

--- a/packages/adapter/adapter-test/readme.md
+++ b/packages/adapter/adapter-test/readme.md
@@ -4,5 +4,4 @@ Test your HatTip endpoints without running a server.
 
 # TODO
 
-- [] License. Use MIT like other packages?
 - [] Add packaging config.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,7 +213,6 @@ importers:
       '@cyco130/eslint-config': ^2.1.2
       '@hattip/core': workspace:*
       '@hattip/polyfills': workspace:*
-      '@types/set-cookie-parser': ^2.4.2
       eslint: ^8.26.0
       publint: ^0.1.9
       tsup: ^6.6.3
@@ -224,7 +223,6 @@ importers:
       '@hattip/polyfills': link:../../base/polyfills
     devDependencies:
       '@cyco130/eslint-config': 2.1.3_7kw3g6rralp5ps6mg3uyzz6azm
-      '@types/set-cookie-parser': 2.4.2
       eslint: 8.34.0
       publint: 0.1.9
       tsup: 6.6.3_typescript@4.9.5
@@ -3258,12 +3256,6 @@ packages:
       '@types/mime': 3.0.1
       '@types/node': 18.14.0
     dev: false
-
-  /@types/set-cookie-parser/2.4.2:
-    resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
-    dependencies:
-      '@types/node': 18.14.1
-    dev: true
 
   /@types/stack-trace/0.0.29:
     resolution: {integrity: sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==}


### PR DESCRIPTION
This PR attaches MIT license file to `adapter-test` package and fixes some files related to the license.