### PR TITLE
Add NodePlatformInfo generic to createServer handler arg in common.ts

### DIFF
--- a/packages/adapter/adapter-node/src/common.ts
+++ b/packages/adapter/adapter-node/src/common.ts
@@ -124,7 +124,7 @@ export function createMiddleware(
  * Create an HTTP server
  */
 export function createServer(
-	handler: HattipHandler,
+	handler: HattipHandler<NodePlatformInfo>,
 	adapterOptions?: NodeAdapterOptions,
 	serverOptions?: ServerOptions,
 ): HttpServer {


### PR DESCRIPTION
Adds the `NodePlatformInfo` generic to the `createServer` handler arg in `common.ts` in the adapter-node package

Similar to how it is already used in `createMiddleware`

This is to prevent this type error when you strictly type your handler to the node platform before passing it into createServer:

```
Argument of type 'HattipHandler<NodePlatformInfo>' is not assignable to parameter of type 'HattipHandler'.
  Type 'unknown' is not assignable to type 'NodePlatformInfo'.ts(2345)
```