### PR TITLE
fix(graphql): put graphql-yoga back into prod deps to reexport its types

### DIFF
--- a/packages/middleware/graphql/package.json
+++ b/packages/middleware/graphql/package.json
@@ -41,12 +41,12 @@
     "@hattip/compose": "workspace:*",
     "@hattip/core": "workspace:*",
     "dset": "^3.1.2",
+    "graphql-yoga": "^4.0.4",
     "tslib": "^2.6.2",
     "urlpattern-polyfill": "^9.0.0"
   },
   "devDependencies": {
     "@graphql-yoga/subscription": "^4.0.0",
-    "graphql-yoga": "^4.0.4",
     "@cyco130/eslint-config": "^3.3.2",
     "@hattip/polyfills": "workspace:*",
     "@types/node": "^20.5.7",

--- a/packages/middleware/graphql/tsup.config.ts
+++ b/packages/middleware/graphql/tsup.config.ts
@@ -12,6 +12,10 @@ export default defineConfig([
 		target: "node14",
 		shims: false,
 		dts: true,
+		// We wan't to bundle graphql-yoga so that we can use the
+		// global fetch instead of @whatwg-node/fetch. But we still
+		// want graphql-yoga in the dependencies to be able to resolve
+		// the types.
 		noExternal: ["graphql-yoga"],
 		esbuildPlugins: [
 			{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -898,6 +898,9 @@ importers:
       dset:
         specifier: ^3.1.2
         version: 3.1.2
+      graphql-yoga:
+        specifier: ^4.0.4
+        version: 4.0.4(graphql@16.8.0)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -923,9 +926,6 @@ importers:
       graphql:
         specifier: ^16.8.0
         version: 16.8.0
-      graphql-yoga:
-        specifier: ^4.0.4
-        version: 4.0.4(graphql@16.8.0)
       publint:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1758,14 +1758,14 @@ packages:
     dependencies:
       '@envelop/types': 4.0.0
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /@envelop/types@4.0.0:
     resolution: {integrity: sha512-dmBK16VVfKCkqYYemvE+gt1cPBP0d9CbYO4yjNhSSYy9K+w6+Lw48wOLK238mSR339PNAvwj/JW/qzNy2llggA==}
     engines: {node: '>=16.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /@esbuild-kit/cjs-loader@2.4.2:
     resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
@@ -2680,7 +2680,7 @@ packages:
       graphql: 16.8.0
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: true
+    dev: false
 
   /@graphql-tools/merge@9.0.0(graphql@16.8.0):
     resolution: {integrity: sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==}
@@ -2691,6 +2691,7 @@ packages:
       '@graphql-tools/utils': 10.0.5(graphql@16.8.0)
       graphql: 16.8.0
       tslib: 2.6.2
+    dev: false
 
   /@graphql-tools/schema@10.0.0(graphql@16.8.0):
     resolution: {integrity: sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==}
@@ -2703,6 +2704,7 @@ packages:
       graphql: 16.8.0
       tslib: 2.6.2
       value-or-promise: 1.0.12
+    dev: false
 
   /@graphql-tools/utils@10.0.5(graphql@16.8.0):
     resolution: {integrity: sha512-ZTioQqg9z9eCG3j+KDy54k1gp6wRIsLqkx5yi163KVvXVkfjsrdErCyZjrEug21QnKE9piP4tyxMpMMOT1RuRw==}
@@ -2714,6 +2716,7 @@ packages:
       dset: 3.1.2
       graphql: 16.8.0
       tslib: 2.6.2
+    dev: false
 
   /@graphql-typed-document-node/core@3.2.0(graphql@16.8.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -2721,13 +2724,14 @@ packages:
       graphql: ^16.8.0
     dependencies:
       graphql: 16.8.0
+    dev: false
 
   /@graphql-yoga/logger@1.0.0:
     resolution: {integrity: sha512-JYoxwnPggH2BfO+dWlWZkDeFhyFZqaTRGLvFhy+Pjp2UxitEW6nDrw+pEDw/K9tJwMjIFMmTT9VfTqrnESmBHg==}
     engines: {node: '>=16.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /@graphql-yoga/subscription@4.0.0:
     resolution: {integrity: sha512-0qsN/BPPZNMoC2CZ8i+P6PgiJyHh1H35aKDt37qARBDaIOKDQuvEOq7+4txUKElcmXi7DYFo109FkhSQoEajrg==}
@@ -2737,7 +2741,6 @@ packages:
       '@repeaterjs/repeater': 3.0.4
       '@whatwg-node/events': 0.1.1
       tslib: 2.6.2
-    dev: true
 
   /@graphql-yoga/typed-event-target@2.0.0:
     resolution: {integrity: sha512-oA/VGxGmaSDym1glOHrltw43qZsFwLLjBwvh57B79UKX/vo3+UQcRgOyE44c5RP7DCYjkrC2tuArZmb6jCzysw==}
@@ -2745,7 +2748,6 @@ packages:
     dependencies:
       '@repeaterjs/repeater': 3.0.4
       tslib: 2.6.2
-    dev: true
 
   /@grpc/grpc-js@1.8.17:
     resolution: {integrity: sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==}
@@ -4125,7 +4127,6 @@ packages:
 
   /@repeaterjs/repeater@3.0.4:
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
-    dev: true
 
   /@rollup/pluginutils@4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -4684,7 +4685,7 @@ packages:
     dependencies:
       '@whatwg-node/node-fetch': 0.4.7
       urlpattern-polyfill: 9.0.0
-    dev: true
+    dev: false
 
   /@whatwg-node/fetch@0.9.9:
     resolution: {integrity: sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==}
@@ -4714,7 +4715,7 @@ packages:
       fast-querystring: 1.1.2
       fast-url-parser: 1.1.3
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /@whatwg-node/server@0.9.2:
     resolution: {integrity: sha512-W8CzF9Lvu/AKE+HFmKmTwJZ91G+zPmn0zjsl47hjcY5y0/kZqkCqwB86c0y8rRf8+bV5hJ2ChDK8otN0y6fzng==}
@@ -4722,7 +4723,7 @@ packages:
     dependencies:
       '@whatwg-node/fetch': 0.9.8
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /@xhmikosr/archive-type@6.0.1:
     resolution: {integrity: sha512-PB3NeJL8xARZt52yDBupK0dNPn8uIVQDe15qNehUpoeeLWCZyAOam4vGXnoZGz2N9D1VXtjievJuCsXam2TmbQ==}
@@ -6415,6 +6416,7 @@ packages:
   /dset@3.1.2:
     resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
     engines: {node: '>=4'}
+    dev: false
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -7297,6 +7299,7 @@ packages:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
     dependencies:
       punycode: 1.4.1
+    dev: false
 
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -7975,7 +7978,7 @@ packages:
       graphql: 16.8.0
       lru-cache: 10.0.0
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /graphql@16.8.0:
     resolution: {integrity: sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==}
@@ -9225,7 +9228,6 @@ packages:
   /lru-cache@10.0.0:
     resolution: {integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -10815,6 +10817,7 @@ packages:
 
   /punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+    dev: false
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -12643,6 +12646,7 @@ packages:
 
   /urlpattern-polyfill@9.0.0:
     resolution: {integrity: sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==}
+    dev: false
 
   /use@3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
@@ -12695,6 +12699,7 @@ packages:
   /value-or-promise@1.0.12:
     resolution: {integrity: sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==}
     engines: {node: '>=12'}
+    dev: false
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}


### PR DESCRIPTION
The `@hattip/graphql` package bundles `graphql-yoga` to be able to remove its dependency on the `@whatwg-node/fetch` package in favor of the global fetch. But it should still be included in the dependencies to be able to resolve the types.