### PR TITLE
feat!: drop Node 16 support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,11 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:base", "schedule:weekly", "group:allNonMajor"],
 	"ignorePresets": ["ignorePaths"],
-	"ignorePaths": ["**/node_modules/**", "**/dist/**"],
+	"ignorePaths": [
+		"**/node_modules/**",
+		"**/dist/**",
+		"testbed/basic/fastly/package.json"
+	],
 	"labels": ["dependencies"],
 	"rangeStrategy": "bump",
 	"packageRules": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node_version: [18]
+        node_version: [20]
         include:
           - os: ubuntu-latest
-            node_version: 16
+            node_version: 18
           - os: ubuntu-latest
-            node_version: 20
+            node_version: 21
       fail-fast: false
     name: "CI tests on node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         node_version: [20]
         include:
           - os: ubuntu-latest
             node_version: 18
           - os: ubuntu-latest
             node_version: 21
+          - os: windows-latest
+            node_version: 21 # Node 20 has a Unicode bug on Windows
       fail-fast: false
     name: "CI tests on node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: "CI tests on node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Deno
         uses: denoland/setup-deno@v1
@@ -52,7 +52,7 @@ jobs:
           version: 8
 
       - name: Set Node version to ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           check-latest: true

--- a/.github/workflows/cq.yml
+++ b/.github/workflows/cq.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Code quality checks"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -31,7 +31,7 @@ jobs:
           version: 8
 
       - name: Set Node version to 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           check-latest: true

--- a/.github/workflows/cq.yml
+++ b/.github/workflows/cq.yml
@@ -19,13 +19,8 @@ defaults:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node_version: [18.14.2]
-      fail-fast: false
-    name: "Code quality checks on node-${{ matrix.node_version }}, ${{ matrix.os }}"
+    runs-on: ubuntu-latest
+    name: "Code quality checks"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,10 +30,11 @@ jobs:
         with:
           version: 8
 
-      - name: Set Node version to ${{ matrix.node_version }}
+      - name: Set Node version to 20
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: 20
+          check-latest: true
           cache: "pnpm"
 
       - name: Install

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           version: 8
 
-      - name: Set Node version to 18
+      - name: Set Node version to 20
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: "pnpm"
 
       - name: Install Deno

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,7 +18,7 @@ jobs:
     name: "Publish to deno.land/x"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -26,7 +26,7 @@ jobs:
           version: 8
 
       - name: Set Node version to 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
@@ -43,7 +43,7 @@ jobs:
         run: pnpm -r --filter=@hattip/graphql --filter=@hattip/compose build
 
       - name: Checkout the Deno release repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: hattipjs/deno-release
           path: _deno

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
         id: comment-branch
 
       - name: Checkout ${{ steps.comment-branch.outputs.head_ref }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
           version: 8
 
       - name: Set Node version to 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           version: 8
 
-      - name: Set Node version to 18
+      - name: Set Node version to 20
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           version: 8
 
-      - name: Set Node version to 18
+      - name: Set Node version to 20
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
     name: "Publish to NPM"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -36,7 +36,7 @@ jobs:
           version: 8
 
       - name: Set Node version to 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"

--- a/examples/basic/node/package.json
+++ b/examples/basic/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hattip/example-basic",
+  "name": "@hattip/example-basic-node",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,7 +9,7 @@
   "dependencies": {
     "@hattip/adapter-cloudflare-workers": "workspace:*",
     "@hattip/adapter-node": "workspace:*",
-    "@types/node": "^20.5.7",
-    "wrangler": "^3.6.0"
+    "@types/node": "^20.10.6",
+    "wrangler": "^3.22.1"
   }
 }

--- a/examples/vite/hono/package.json
+++ b/examples/vite/hono/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hattip/example-cli-playground",
+  "name": "@hattip/example-vite-hono",
   "type": "module",
   "private": true,
   "scripts": {
@@ -11,7 +11,7 @@
     "@hattip/adapter-node": "workspace:*",
     "@hattip/core": "workspace:*",
     "@hattip/vite": "workspace:*",
-    "hono": "^3.5.5",
+    "hono": "^3.11.11",
     "vite": "^5.0.10"
   }
 }

--- a/examples/vite/playground/package.json
+++ b/examples/vite/playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hattip/example-cli-playground",
+  "name": "@hattip/example-vite-playground",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/adapter/adapter-bun/tsup.config.ts
+++ b/packages/adapter/adapter-bun/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/adapter/adapter-cloudflare-workers/tsup.config.ts
+++ b/packages/adapter/adapter-cloudflare-workers/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/no-static.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 		external: ["__STATIC_CONTENT_MANIFEST"],

--- a/packages/adapter/adapter-deno/tsup.config.ts
+++ b/packages/adapter/adapter-deno/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/adapter/adapter-fastly/tsup.config.ts
+++ b/packages/adapter/adapter-fastly/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 		external: ["fastly:env"],

--- a/packages/adapter/adapter-lagon/tsup.config.ts
+++ b/packages/adapter/adapter-lagon/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/adapter/adapter-netlify-edge/tsup.config.ts
+++ b/packages/adapter/adapter-netlify-edge/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/adapter/adapter-netlify-functions/tsup.config.ts
+++ b/packages/adapter/adapter-netlify-functions/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 		external: ["__STATIC_CONTENT_MANIFEST"],

--- a/packages/adapter/adapter-node/tsup.config.ts
+++ b/packages/adapter/adapter-node/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig([
 		],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: true,
 	},
 ]);

--- a/packages/adapter/adapter-test/tsup.config.ts
+++ b/packages/adapter/adapter-test/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
 	entry: ["./src/index.ts"],
 	format: ["esm"],
 	platform: "node",
-	target: "node14",
+	target: "node18",
 	shims: false,
 	dts: true,
 });

--- a/packages/adapter/adapter-uwebsockets/tsup.config.ts
+++ b/packages/adapter/adapter-uwebsockets/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/native-fetch.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: true,
 	},
 ]);

--- a/packages/base/compose/tsup.config.ts
+++ b/packages/base/compose/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: true,
 	},
 ]);

--- a/packages/base/headers/tsup.config.ts
+++ b/packages/base/headers/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/base/multipart/tsup.config.ts
+++ b/packages/base/multipart/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: true,
 	},
 ]);

--- a/packages/base/polyfills/tsup.config.ts
+++ b/packages/base/polyfills/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig([
 		],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: true,
 	},
 ]);

--- a/packages/base/response/tsup.config.ts
+++ b/packages/base/response/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/base/router/tsup.config.ts
+++ b/packages/base/router/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: true,
 	},
 ]);

--- a/packages/bundler/bundler-cloudflare-workers/tsup.config.ts
+++ b/packages/bundler/bundler-cloudflare-workers/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/cli.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: true,
 	},
 ]);

--- a/packages/bundler/bundler-deno/tsup.config.ts
+++ b/packages/bundler/bundler-deno/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/cli.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: "./src/index.ts",
 	},
 ]);

--- a/packages/bundler/bundler-netlify/tsup.config.ts
+++ b/packages/bundler/bundler-netlify/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/cli.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: {
 			entry: "./src/index.ts",
 		},

--- a/packages/bundler/bundler-vercel/tsup.config.ts
+++ b/packages/bundler/bundler-vercel/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/cli.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		dts: {
 			entry: "./src/index.ts",
 		},

--- a/packages/bundler/walk/tsup.config.ts
+++ b/packages/bundler/walk/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/cli.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: { entry: ["./src/index.ts"] },
 	},

--- a/packages/cli/vite/package.json
+++ b/packages/cli/vite/package.json
@@ -38,7 +38,7 @@
     "suppress-loader-warnings.cjs"
   ],
   "peerDependencies": {
-    "vite": "4"
+    "vite": "4 | 5"
   },
   "devDependencies": {
     "@cyco130/eslint-config": "^3.5.0",

--- a/packages/middleware/cookie/tsup.config.ts
+++ b/packages/middleware/cookie/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/parse.ts", "./src/serialize.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/middleware/cors/tsup.config.ts
+++ b/packages/middleware/cors/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/middleware/graphql/tsup.config.ts
+++ b/packages/middleware/graphql/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig([
 		entry: ["./src/index.ts", "./src/yoga.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 		// We wan't to bundle graphql-yoga so that we can use the

--- a/packages/middleware/session/tsup.config.ts
+++ b/packages/middleware/session/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
 		entry: ["./src/index.ts"],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		dts: true,
 	},

--- a/packages/middleware/static/tsup.config.ts
+++ b/packages/middleware/static/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig([
 		],
 		format: ["esm"],
 		platform: "node",
-		target: "node14",
+		target: "node18",
 		shims: false,
 		external: ["__STATIC_CONTENT_MANIFEST"],
 		dts: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/adapter/adapter-node
       '@types/node':
-        specifier: ^20.5.7
+        specifier: ^20.10.6
         version: 20.10.6
       wrangler:
-        specifier: ^3.6.0
+        specifier: ^3.22.1
         version: 3.22.1
 
   examples/vite/hono:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/cli/vite
       hono:
-        specifier: ^3.5.5
+        specifier: ^3.11.11
         version: 3.11.11
       vite:
         specifier: ^5.0.10


### PR DESCRIPTION
This PR drops Node 16 support and changes build and PR scripts to use Node 18 as the minimum. Main CI Node version is also upgraded to Node 20.