### PR TITLE
chore: fix incorrect vite peer version

### DIFF
--- a/packages/cli/vite/package.json
+++ b/packages/cli/vite/package.json
@@ -38,7 +38,7 @@
     "suppress-loader-warnings.cjs"
   ],
   "peerDependencies": {
-    "vite": "^4 | ^5"
+    "vite": "^4 || ^5"
   },
   "devDependencies": {
     "@cyco130/eslint-config": "^3.9.1",


### PR DESCRIPTION
`vite` was using `|` rather than `||`