### PR TITLE
fix: cookies of request for aws lambda payload format v2

### DIFF
--- a/packages/adapter/adapter-aws-lambda/src/index.ts
+++ b/packages/adapter/adapter-aws-lambda/src/index.ts
@@ -37,6 +37,10 @@ export default function awsLambdaAdapter(
 			event.rawPath +
 			(event.rawQueryString ? "?" + event.rawQueryString : "");
 
+		if (event.cookies != null && event.cookies.length > 0) {
+			event.headers["cookie"] = event.cookies.join("; ");
+		}
+
 		const ctx: AdapterRequestContext<AwsLambdaPlatformInfo> = {
 			request: new Request(url, {
 				method: event.requestContext?.http?.method || "GET",

--- a/packages/adapter/adapter-aws-lambda/src/index.ts
+++ b/packages/adapter/adapter-aws-lambda/src/index.ts
@@ -37,7 +37,11 @@ export default function awsLambdaAdapter(
 			event.rawPath +
 			(event.rawQueryString ? "?" + event.rawQueryString : "");
 
-		if (event.cookies != null && event.cookies.length > 0) {
+		if (
+			typeof event.headers.cookie === "undefined" &&
+			event.cookies != null &&
+			event.cookies.length > 0
+		) {
 			event.headers["cookie"] = event.cookies.join("; ");
 		}
 


### PR DESCRIPTION
Put cookies back to headers to construct a complete request for hattip handler.