### PR TITLE
fix: node.js entry option parsing for build command

### DIFF
--- a/packages/cli/vite/src/index.ts
+++ b/packages/cli/vite/src/index.ts
@@ -148,7 +148,7 @@ cli
 	.command("build [hattip-entry]", "Build for production")
 
 	.option("-r, --root", "[string] project root")
-	.option("-n, --node", "[string] Node.js entry")
+	.option("-n, --node <node-entry>", "[string] Node.js entry")
 	.option("-C, --client [client-entry]", "[string] client entry")
 
 	.option("--target <target>", `[string] transpile target (default: 'modules')`)

--- a/packages/cli/vite/src/index.ts
+++ b/packages/cli/vite/src/index.ts
@@ -86,7 +86,7 @@ cli
 	.alias("serve")
 
 	.option("-r, --root", "[string] project root")
-	.option("-n, --node", "[string] Node.js entry")
+	.option("-n, --node <node-entry>", "[string] Node.js entry")
 	.option(
 		"-C, --client [client-entry]",
 		"[string] client entry (can be repeated)",


### PR DESCRIPTION
Fix the parsing of custom node.js entry for build command of CLI.

`hattip build ./entry-hattip.ts -n ./entry-node.ts`