### PR TITLE
fix: implement request cancelation

### DIFF
--- a/packages/adapter/adapter-node/src/common.ts
+++ b/packages/adapter/adapter-node/src/common.ts
@@ -22,7 +22,7 @@ interface PossiblyEncryptedSocket extends Socket {
 export interface DecoratedRequest extends Omit<IncomingMessage, "socket"> {
 	ip?: string;
 	protocol?: string;
-	socket?: PossiblyEncryptedSocket;
+	socket: PossiblyEncryptedSocket;
 }
 
 /** Connect/Express style request listener/middleware */
@@ -61,7 +61,7 @@ export function createMiddleware(
 
 	return async (req, res, next) => {
 		try {
-			const [request, ip] = requestAdapter(req);
+			const [request, ip] = requestAdapter(req, res);
 
 			let passThroughCalled = false;
 
@@ -97,7 +97,7 @@ export function createMiddleware(
 				return;
 			}
 
-			await sendResponse(response, res);
+			await sendResponse(req, res, response);
 
 			if (next && alwaysCallNext) {
 				next();

--- a/testbed/basic/ci.test.ts
+++ b/testbed/basic/ci.test.ts
@@ -500,6 +500,33 @@ describe.each(cases)(
 			const text2 = await response2.text();
 			expect(text2).toEqual("You have visited this page 2 time(s).");
 		});
+
+		/* Only run manually
+		test.only("cancels response stream when client disconnects", async () => {
+			const controller = new AbortController();
+			const { signal } = controller;
+
+			const response = await fetch(host + "/abort", { signal });
+			const stream = response.body!;
+
+			for await (const chunk of stream) {
+				expect(chunk.slice(0, 4)).toStrictEqual(new Uint8Array([1, 2, 3, 4]));
+				break;
+			}
+
+			controller.abort();
+
+			await new Promise((resolve) => {
+				setTimeout(resolve, 1000);
+			});
+
+			const result = await fetch(host + "/abort-check").then((r) => r.json());
+			expect(result).toStrictEqual({
+				aborted: true,
+				intervalCleared: true,
+			});
+		});
+		*/
 	},
 );
 


### PR DESCRIPTION
This PR implements request cancelation and `request.signal` for Node and uWebSockets adapters.

Fixes #161 