### PR TITLE
feat: add `AdapterEnv` interface for ambient extension

### DIFF
--- a/packages/base/core/index.d.ts
+++ b/packages/base/core/index.d.ts
@@ -5,6 +5,10 @@ export interface AdapterEnv {}
 
 export type AdapterEnvKey = keyof AdapterEnv | (string & {});
 
+export type AdapterEnvGetter = <K extends AdapterEnvKey>(
+	variable: K,
+) => K extends keyof AdapterEnv ? AdapterEnv[K] : string | undefined;
+
 /**
  * Request context as dispatched by the platform adapter
  */
@@ -31,9 +35,7 @@ export interface AdapterRequestContext<P = unknown> {
 	 *
 	 * @returns The value of the variable or undefined if it doesn't exist.
 	 */
-	env<K extends AdapterEnvKey>(
-		variable: K,
-	): K extends keyof AdapterEnv ? AdapterEnv[K] : string | undefined;
+	env: AdapterEnvGetter;
 	/**
 	 * Signal that the request hasn't been handled and the returned response is
 	 * a placeholder (usually a 404). In this case the adapter should handle the

--- a/packages/base/core/index.d.ts
+++ b/packages/base/core/index.d.ts
@@ -1,4 +1,11 @@
 /**
+ * Interface defining the shape of environment variables
+ */
+export interface AdapterEnv {}
+
+export type AdapterEnvKey = keyof AdapterEnv | (string & {});
+
+/**
  * Request context as dispatched by the platform adapter
  */
 export interface AdapterRequestContext<P = unknown> {
@@ -24,7 +31,9 @@ export interface AdapterRequestContext<P = unknown> {
 	 *
 	 * @returns The value of the variable or undefined if it doesn't exist.
 	 */
-	env(variable: string): string | undefined;
+	env<K extends AdapterEnvKey>(
+		variable: K,
+	): K extends keyof AdapterEnv ? AdapterEnv[K] : string | undefined;
 	/**
 	 * Signal that the request hasn't been handled and the returned response is
 	 * a placeholder (usually a 404). In this case the adapter should handle the


### PR DESCRIPTION
The `AdapterRequestContext#env` method uses this interface to provide type safety at compile-time. It allows the user to make certain assumptions about the existence of particular environment variables.
