### PR TITLE
fix(adapter-test): loosen `env` argument for easy `process.env` forwarding

### DIFF
--- a/packages/adapter/adapter-test/src/index.ts
+++ b/packages/adapter/adapter-test/src/index.ts
@@ -7,7 +7,7 @@ export interface CreateTestClientArgs<P = unknown> {
 	handler: HattipHandler<P>;
 	baseUrl?: string | URL;
 	platform?: P;
-	env?: Record<string, string>;
+	env?: Record<string, string | undefined>;
 }
 
 export function createTestClient<P = { name: "test" }>({
@@ -38,7 +38,7 @@ export function createTestClient<P = { name: "test" }>({
 				void promise;
 			},
 			env(variable) {
-				return env[variable];
+				return env[variable] as any;
 			},
 		});
 	};

--- a/packages/base/core/index.d.ts
+++ b/packages/base/core/index.d.ts
@@ -5,6 +5,10 @@ export interface AdapterEnv {}
 
 export type AdapterEnvKey = keyof AdapterEnv | (string & {});
 
+export type AdapterEnvGetter = <K extends AdapterEnvKey>(
+	variable: K,
+) => K extends keyof AdapterEnv ? AdapterEnv[K] : string | undefined;
+
 /**
  * Request context as dispatched by the platform adapter
  */
@@ -31,9 +35,7 @@ export interface AdapterRequestContext<P = unknown> {
 	 *
 	 * @returns The value of the variable or undefined if it doesn't exist.
 	 */
-	env<K extends AdapterEnvKey>(
-		variable: K,
-	): K extends keyof AdapterEnv ? AdapterEnv[K] : string | undefined;
+	env: AdapterEnvGetter;
 	/**
 	 * Signal that the request hasn't been handled and the returned response is
 	 * a placeholder (usually a 404). In this case the adapter should handle the

--- a/packages/base/core/index.d.ts
+++ b/packages/base/core/index.d.ts
@@ -1,4 +1,11 @@
 /**
+ * Interface defining the shape of environment variables
+ */
+export interface AdapterEnv {}
+
+export type AdapterEnvKey = keyof AdapterEnv | (string & {});
+
+/**
  * Request context as dispatched by the platform adapter
  */
 export interface AdapterRequestContext<P = unknown> {
@@ -24,7 +31,9 @@ export interface AdapterRequestContext<P = unknown> {
 	 *
 	 * @returns The value of the variable or undefined if it doesn't exist.
 	 */
-	env(variable: string): string | undefined;
+	env<K extends AdapterEnvKey>(
+		variable: K,
+	): K extends keyof AdapterEnv ? AdapterEnv[K] : string | undefined;
 	/**
 	 * Signal that the request hasn't been handled and the returned response is
 	 * a placeholder (usually a 404). In this case the adapter should handle the


### PR DESCRIPTION
While `process.env` (from `@types/node`) has `Record<string, string | undefined>` type, the `env` argument of `@hattip/adapter-test` expects a `Record<string, string>` type. I believe this is more strict than necessary. It'd be great to be able to pass `process.env` in without a type assertion.

**Note:** This builds upon #197 and so that PR should be merged first. Only [this commit](https://github.com/hattipjs/hattip/pull/201/commits/6f1c36a22bfe713bc864c24b548481cc14f2e50f) is relevant to *this* PR.